### PR TITLE
Add Endpoint::Renderer::RenderError error class

### DIFF
--- a/lib/cape/endpoint/renderer.rb
+++ b/lib/cape/endpoint/renderer.rb
@@ -2,6 +2,12 @@ module Cape
   class Endpoint
     module Renderer
 
+      # A RenderError can be used to indicate that rendering has failed for
+      # some reason. More specific errors in a renderer should inherit from
+      # this class so that a Cape::API class can rescue all errors within
+      # rendering by rescuing Endpoint::Renderer::RenderError.
+      class RenderError < StandardError; end
+
       autoload :Base,   'cape/endpoint/renderer/base'
       autoload :Simple, 'cape/endpoint/renderer/simple'
       autoload :Tilt,   'cape/endpoint/renderer/tilt'

--- a/lib/cape/endpoint/renderer/tilt.rb
+++ b/lib/cape/endpoint/renderer/tilt.rb
@@ -3,7 +3,7 @@ module Cape
     module Renderer
       class Tilt < Base
 
-        class MissingTemplate < StandardError
+        class MissingTemplate < RenderError
         end
 
         class << self


### PR DESCRIPTION
In order to allow APIs to rescue general errors during rendering, the
Renderer module should provide a base error type that can be rescued in
an API. For example:

``` ruby
  begin
    render resource
  rescue Endpoint::Renderer::RenderError
    # Handle the error your way
  end
```
