### PR TITLE
Cleanup Util::HashStack by simplifying and removing unused methods

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -46,7 +46,7 @@ module Crepe
       end
 
       def inherited subclass
-        subclass.config = Util.deep_dup config
+        subclass.config = config.dup
       end
 
       def namespace path, options = {}, &block


### PR DESCRIPTION
Just some easy cleanup and simplification. Also, since HashStack is only used in specific ways and doesn't have to ducktype Hash perfectly, we can remove methods that we aren't using.
