### PR TITLE
Add HTTP caching logic

### DIFF
--- a/lib/crepe/endpoint/request.rb
+++ b/lib/crepe/endpoint/request.rb
@@ -54,6 +54,16 @@ module Crepe
         end
       end
 
+      def if_modified_since
+        datetime = headers['If-Modified-Since']
+        Time.httpdate datetime if datetime
+      end
+      alias last_modified if_modified_since
+
+      def if_none_match
+        headers['If-None-Match']
+      end
+      alias etag if_none_match
     end
   end
 end


### PR DESCRIPTION
Not sure I love this implementation. It's based loosely on Sinatra and Rails.

The benefit of owning this logic is that we can avoid rendering objects and return Not Modified (rather than relying on Rack::ETag and Rack::ConditionalGet, which use the rendered body for comparison).
