### PR TITLE
Don't define OPTIONS route for paths that do not define methods

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -228,6 +228,8 @@ module Crepe
           paths = config[:routes].group_by { |_, cond| cond[:path_info] }
           paths.each do |path, routes|
             allowed = routes.map { |_, cond| cond[:request_method] }
+            next if allowed.none?
+
             allowed << 'HEAD' if allowed.include? 'GET'
             allowed << 'OPTIONS'
             allowed.sort!


### PR DESCRIPTION
This fixes a bug where mounting another Crepe::API app at a path produces an allowed array of `[nil]` which throws an error on `#sort!`.

If a path doesn't have any methods defined, it's because the endpoint wants to handle routing itself (ie. it's probably another Rack app), so we want to delegate generation of OPTIONS routes for that path to the Rack app if it decides to.
