### PR TITLE
Rename Crepe::Renderer::Base -> Crepe::Renderer::Paginate

### DIFF
--- a/lib/crepe/renderer.rb
+++ b/lib/crepe/renderer.rb
@@ -8,9 +8,9 @@ module Crepe
     class RenderError < StandardError
     end
 
-    autoload :Base,   'crepe/renderer/base'
-    autoload :Simple, 'crepe/renderer/simple'
-    autoload :Tilt,   'crepe/renderer/tilt'
+    autoload :Paginate, 'crepe/renderer/paginate'
+    autoload :Simple,   'crepe/renderer/simple'
+    autoload :Tilt,     'crepe/renderer/tilt'
 
   end
 end

--- a/lib/crepe/renderer/paginate.rb
+++ b/lib/crepe/renderer/paginate.rb
@@ -2,8 +2,8 @@ require 'uri'
 
 module Crepe
   module Renderer
-    # A base renderer class that sets pagination headers.
-    class Base
+    # A base renderer class that attempts to paginate and set link headers.
+    class Paginate
 
       # Generates pagination links based on provided page, limit, and total.
       class Links < Struct.new :page, :per_page, :count

--- a/lib/crepe/renderer/simple.rb
+++ b/lib/crepe/renderer/simple.rb
@@ -1,7 +1,7 @@
 module Crepe
   module Renderer
     # The simplest renderer delegates rendering to the resource itself.
-    class Simple < Base
+    class Simple < Paginate
 
       def render resource, options = {}
         resource = super

--- a/lib/crepe/renderer/tilt.rb
+++ b/lib/crepe/renderer/tilt.rb
@@ -6,7 +6,7 @@ module Crepe
     # return a {.model_name}.
     #
     # [Tilt]: https://github.com/rtomayko/tilt
-    class Tilt < Base
+    class Tilt < Paginate
 
       # Raised when a template name is derived but cannot be found in the
       # template path.


### PR DESCRIPTION
`Base` was never a good name for the renderer since it's usable on its own and is specifically doing the job of pagination. This makes things a little easier to understand.
