### PR TITLE
Add streaming callbacks

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -95,18 +95,15 @@ module Crepe
         }
       end
 
-      def before mod = nil, &block
-        warn 'block takes precedence over module' if block && mod
-        callback = block || mod
-        raise ArgumentError, 'block or module required' unless callback
-        config[:endpoint][:callbacks][:before] << callback
-      end
-
-      def after mod = nil, &block
-        warn 'block takes precedence over module' if block && mod
-        callback = block || mod
-        raise ArgumentError, 'block or module required' unless callback
-        config[:endpoint][:callbacks][:after] << callback
+      Endpoint.default_config[:callbacks].each_key do |type|
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def #{type} mod = nil, &block
+            warn 'block takes precedence over module' if block && mod
+            callback = block || mod
+            raise ArgumentError, 'block or module required' unless callback
+            config[:endpoint][:callbacks][:#{type}] << callback
+          end
+        RUBY
       end
 
       def basic_auth *args, &block

--- a/lib/crepe/endpoint.rb
+++ b/lib/crepe/endpoint.rb
@@ -11,10 +11,12 @@ module Crepe
         {
           callbacks: {
             after: [],
+            after_stream: [],
             before: [
               Filter::Acceptance,
               Filter::Parser
-            ]
+            ],
+            before_stream: []
           },
           formats: [:json],
           handler: nil,
@@ -118,8 +120,10 @@ module Crepe
         headers['rack.hijack'] = -> io do
           begin
             @stream = io
+            run_callbacks :before_stream
             yield
           ensure
+            run_callbacks :after_stream
             io.close
           end
         end


### PR DESCRIPTION
Streams run in different threads, so callbacks make it simple to manage things like database connections.

``` ruby
after_stream { ActiveRecord::Base.clear_active_connections! }
```

Also simplifies callback logic: Rails has moved on to `before_action` and `after_action`. The Crepe DSL is more like RSpec in how it scopes its endpoints, though, so let's use, simply, `before` and `after`.
