### PR TITLE
Allow namespace to be used without a block, simply update config

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -38,16 +38,14 @@ module Crepe
       end
 
       def namespace path, options = {}, &block
-        if block
-          outer_helper = config[:helper]
-          config.with options.merge(
-            namespace: path,
-            endpoint: Util.deep_dup(config[:endpoint]),
-            helper: Helper.new { include outer_helper }
-          ), &block
-        else
-          config[:namespace] = path
-        end
+        return config.update options.merge(namespace: path) unless block
+
+        outer_helper = config[:helper]
+        config.with options.merge(
+          namespace: path,
+          endpoint: Util.deep_dup(config[:endpoint]),
+          helper: Helper.new { include outer_helper }
+        ), &block
       end
       alias_method :resource, :namespace
 

--- a/lib/crepe/util/hash_stack.rb
+++ b/lib/crepe/util/hash_stack.rb
@@ -14,7 +14,7 @@ module Crepe
         stack.last
       end
 
-      delegate :[]=, :delete,
+      delegate :[]=, :update, :delete,
         to: :top
 
       def key? key

--- a/spec/lib/crepe/api_spec.rb
+++ b/spec/lib/crepe/api_spec.rb
@@ -24,6 +24,29 @@ describe Crepe::API do
     end
   end
 
+  describe '.version' do
+    app { version :v1 and get { 'OK' } }
+
+    it 'adds a namespace' do
+      get('/v1').should be_ok
+    end
+
+    it 'adds the version to content-type' do
+      get('/v1').content_type.should eq 'application/vnd.crepe.v1+json'
+    end
+
+    context 'with a block' do
+      app { version(:v1) { get { 'OK' } } and get { 'OK' } }
+      it 'sets the version for endpoints inside the block' do
+        get('/v1').content_type.should eq 'application/vnd.crepe.v1+json'
+      end
+
+      it 'does not set the version outside the block' do
+        get('/').content_type.should eq 'application/json'
+      end
+    end
+  end
+
   describe '.use' do
     let(:app)    { Class.new base, &routes }
     let(:base)   { Class.new Crepe::API, &routes }


### PR DESCRIPTION
This allows the version helper to be used without a block and simply updates the current config with a namespace and version in header.
