### PR TITLE
Simplify API#scope by pulling key scope into config HashStack

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -50,14 +50,10 @@ module Crepe
       end
 
       def scope namespace = nil, **options, &block
-        return config.update options.merge(namespace: namespace) unless block
-
-        config.with options.merge(
-          namespace: namespace,
-          route_options: normalize_route_options(options),
-          endpoint: config[:endpoint].deep_dup,
-          helper: config[:helper].dup
-        ), &block
+        options = options.merge(
+          namespace: namespace, route_options: normalize_route_options(options)
+        )
+        config.scope :endpoint, :helper, options, &block
       end
       alias namespace scope
       alias resource scope

--- a/lib/crepe/util/hash_stack.rb
+++ b/lib/crepe/util/hash_stack.rb
@@ -14,15 +14,16 @@ module Crepe
         stack.last
       end
 
-      delegate :[], :[]=, :delete, :merge, :update,
+      delegate :[], :[]=, :delete, :merge, :slice, :update,
         to: :now
 
       def all key
-        stack.map { |frame| frame[key] }.flatten 1
+        stack.map { |layer| layer[key] }.flatten 1
       end
 
-      def with frame = {}
-        self << to_hash.deep_merge(frame)
+      def scope *scoped, **updates
+        return update updates unless block_given?
+        push to_hash.deep_merge updates.merge slice(*scoped).deep_dup
         yield
         pop
       end


### PR DESCRIPTION
By letting the HashStack handle the scoping of extended keys to a given block, most of the complexity of #scope can be pushed down.
