### PR TITLE
Pagination should be a module, not a renderer

### DIFF
--- a/lib/crepe/renderer.rb
+++ b/lib/crepe/renderer.rb
@@ -8,9 +8,10 @@ module Crepe
     class RenderError < StandardError
     end
 
-    autoload :Paginate, 'crepe/renderer/paginate'
-    autoload :Simple,   'crepe/renderer/simple'
-    autoload :Tilt,     'crepe/renderer/tilt'
+    autoload :Base,       'crepe/renderer/base'
+    autoload :Pagination, 'crepe/renderer/pagination'
+    autoload :Simple,     'crepe/renderer/simple'
+    autoload :Tilt,       'crepe/renderer/tilt'
 
   end
 end

--- a/lib/crepe/renderer/base.rb
+++ b/lib/crepe/renderer/base.rb
@@ -1,0 +1,20 @@
+module Crepe
+  module Renderer
+    # Basic base class for rendering that stops processing HEAD requests when
+    # called in subclasses.
+    class Base
+
+      attr_reader :endpoint
+
+      def initialize endpoint
+        @endpoint = endpoint
+      end
+
+      def render resource, **options
+        throw :head if endpoint.request.head?
+        resource
+      end
+
+    end
+  end
+end

--- a/lib/crepe/renderer/pagination.rb
+++ b/lib/crepe/renderer/pagination.rb
@@ -2,8 +2,7 @@ require 'uri'
 
 module Crepe
   module Renderer
-    # A base renderer class that attempts to paginate and set link headers.
-    class Paginate
+    module Pagination
 
       # Generates pagination links based on provided page, limit, and total.
       class Links < Struct.new :page, :per_page, :count
@@ -49,12 +48,6 @@ module Crepe
 
       PER_PAGE = 20
 
-      attr_reader :endpoint
-
-      def initialize endpoint
-        @endpoint = endpoint
-      end
-
       def render resource, options = {}
         if resource.respond_to? :paginate
           count = resource.count if resource.respond_to? :count
@@ -70,7 +63,7 @@ module Crepe
           resource = resource.paginate params
         end
 
-        throw :head if endpoint.request.head?
+        super if defined? super
 
         resource
       end

--- a/lib/crepe/renderer/simple.rb
+++ b/lib/crepe/renderer/simple.rb
@@ -1,11 +1,12 @@
 module Crepe
   module Renderer
     # The simplest renderer delegates rendering to the resource itself.
-    class Simple < Paginate
+    class Simple < Base
 
-      def render resource, options = {}
+      include Pagination
+
+      def render resource, format: endpoint.format
         resource = super
-        format = options.fetch :format, endpoint.format
 
         if resource.respond_to? "to_#{format}"
           resource.__send__("to_#{format}")

--- a/lib/crepe/renderer/tilt.rb
+++ b/lib/crepe/renderer/tilt.rb
@@ -8,12 +8,14 @@ module Crepe
     # return a {.model_name}.
     #
     # [Tilt]: https://github.com/rtomayko/tilt
-    class Tilt < Paginate
+    class Tilt < Base
 
       # Raised when a template name is derived but cannot be found in the
       # template path.
       class MissingTemplate < RenderError
       end
+
+      include Pagination
 
       class << self
 


### PR DESCRIPTION
Renderer classes should have the ability to include pagination when they want to without having to rely on inheritance.
