### PR TITLE
Allow OPTIONS requests for formats responded to inside scopes

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -262,13 +262,21 @@ module Crepe
             allowed << 'OPTIONS'
             allowed.sort!
 
-            route 'OPTIONS', path do
-              headers['Allow'] = allowed.join ', '
-              { allow: allowed }
+            formats = options.inject([]) do |f, (_, _, _, config)|
+              f + config[:endpoint][:formats]
             end
-            route METHODS - allowed, path do
-              headers['Allow'] = allowed.join ', '
-              error! :method_not_allowed, allow: allowed
+            formats.uniq!
+
+            scope do
+              respond_to(*formats)
+              route 'OPTIONS', path do
+                headers['Allow'] = allowed.join ', '
+                { allow: allowed }
+              end
+              route METHODS - allowed, path do
+                headers['Allow'] = allowed.join ', '
+                error! :method_not_allowed, allow: allowed
+              end
             end
           end
         end

--- a/spec/crepe/http_methods_spec.rb
+++ b/spec/crepe/http_methods_spec.rb
@@ -2,38 +2,46 @@ require 'spec_helper'
 
 describe Crepe::API, 'HTTP methods' do
   app do
-    get    '/get'
-    post   '/post'
-    put    '/put'
-    patch  '/patch'
-    delete '/delete'
-    any    '/any'
+    scope :method do
+      respond_to :json, :html
+
+      get    '/get'
+      post   '/post'
+      put    '/put'
+      patch  '/patch'
+      delete '/delete'
+      any    '/any'
+    end
   end
 
   methods = Crepe::API::METHODS.map(&:downcase)
   methods.each do |method|
     describe ".#{method}" do
       it "routes #{method.upcase} requests" do
-        send(method, "/#{method}").should be_successful
+        send(method, "/method/#{method}").should be_successful
       end
 
       if method == 'get'
         it "routes HEAD requests" do
-          head("/#{method}").should be_successful
+          head("/method/#{method}").should be_successful
         end
       else
         it "does not route HEAD requests" do
-          head("/#{method}").should be_method_not_allowed
+          head("/method/#{method}").should be_method_not_allowed
         end
       end
 
       it "routes OPTIONS requests" do
-        options("/#{method}").should be_successful
+        options("/method/#{method}").should be_successful
+      end
+
+      it "routes OPTIONS requests other formats" do
+        options("/method/#{method}.html").should be_successful
       end
 
       it "does not route anything else" do
         (methods - [method]).each do |other_method|
-          send(other_method, "/#{method}").should be_method_not_allowed
+          send(other_method, "/method/#{method}").should be_method_not_allowed
         end
       end
     end
@@ -42,7 +50,7 @@ describe Crepe::API, 'HTTP methods' do
   describe ".any" do
     it "routes anything" do
       (methods + %w[head options]).each do |method|
-        send(method, '/any').should be_successful
+        send(method, '/method/any').should be_successful
       end
     end
   end


### PR DESCRIPTION
Because #generate_options_routes! is called after all scopes are unwound, we have to go back and grab the relevant formats when defining the matching OPTIONS routes.
