### PR TITLE
Keep track of the originally set HTTP Status Code

### DIFF
--- a/lib/crepe/endpoint.rb
+++ b/lib/crepe/endpoint.rb
@@ -67,7 +67,10 @@ module Crepe
     end
 
     def status value = nil
-      response.status = Rack::Utils.status_code value if value
+      if value
+        response.status = env['crepe.status'] = Rack::Utils.status_code value
+      end
+
       response.status
     end
 

--- a/lib/crepe/middleware/restful_status.rb
+++ b/lib/crepe/middleware/restful_status.rb
@@ -15,7 +15,7 @@ module Crepe
       def call env
         status, headers, body = @app.call env
 
-        if status == 200
+        if status == 200 && !env['crepe.status']
           case env['REQUEST_METHOD']
           when 'POST'
             status = body.empty? ? 204 : 201

--- a/spec/crepe/restful_status_spec.rb
+++ b/spec/crepe/restful_status_spec.rb
@@ -12,6 +12,12 @@ describe Crepe::API, 'RESTful status' do
       patch  '/patch'
       delete '/delete'
     end
+    namespace :explicit do
+      post   '/post'   do status :accepted end
+      put    '/put'    do status :accepted end
+      patch  '/patch'  do status :accepted end
+      delete '/delete' do status :accepted end
+    end
   end
 
   %w[post put patch delete].each do |method|
@@ -27,6 +33,10 @@ describe Crepe::API, 'RESTful status' do
 
     it "returns 204 No Content for #{method.upcase} without content" do
       send(method, "/empty/#{method}").status.should eq 204
+    end
+
+    it "returns the original status for #{method.upcase} if set explicitly" do
+      send(method, "/explicit/#{method}").status.should eq 202
     end
   end
 end


### PR DESCRIPTION
When explicitly setting the status code in a response, honor that code
in the `RestfulStatus` middleware instead of overriding it with the
status code that the middleware has deemed appropriate.

Signed-off-by: David Celis me@davidcel.is
