### PR TITLE
Remove multi_json gem, rely on Ruby 1.9 JSON

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ PATH
   specs:
     crepe (0.0.1.pre)
       activesupport (>= 4.0.0)
-      multi_json (~> 1.6.x)
       rack (~> 1.5.x)
       rack-mount (~> 0.8.x)
       tilt (~> 1.3.x)

--- a/crepe.gemspec
+++ b/crepe.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'activesupport', '>= 4.0.0'
-  s.add_dependency 'multi_json',    '~> 1.6.x'
   s.add_dependency 'rack',          '~> 1.5.x'
   s.add_dependency 'rack-mount',    '~> 0.8.x'
   s.add_dependency 'tilt',          '~> 1.3.x'

--- a/examples/request_body_parsing.ru
+++ b/examples/request_body_parsing.ru
@@ -1,5 +1,4 @@
 require 'crepe'
-require 'multi_json'
 
 # Parses input and echoes back the Ruby interpretation.
 #

--- a/lib/crepe/parser/simple.rb
+++ b/lib/crepe/parser/simple.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 
 module Crepe
   module Parser
@@ -19,8 +19,8 @@ module Crepe
           request.POST
         when %r{application/json}
           begin
-            MultiJson.load body
-          rescue MultiJson::DecodeError
+            JSON.parse body
+          rescue JSON::ParserError
             error! :bad_request, "Invalid JSON"
           end
         else

--- a/lib/crepe/renderer/simple.rb
+++ b/lib/crepe/renderer/simple.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 
 module Crepe
   module Renderer
@@ -11,7 +11,11 @@ module Crepe
         resource = super
 
         if format == :json
-          MultiJson.dump resource, pretty: endpoint.params[:pretty]
+          if endpoint.request.GET.key? 'pretty'
+            JSON.pretty_generate resource
+          else
+            JSON.dump resource
+          end
         elsif resource.respond_to? "to_#{format}"
           resource.__send__ "to_#{format}"
         else


### PR DESCRIPTION
MultiJson isn't all its cracked up to be. It can introduce slowness, its been removed as a dependency in activesupport, and there's now full, fast support for JSON in Ruby 1.9+. More info: https://github.com/intridea/multi_json/pull/113

The fewer dependencies Crepe relies on, the better. If you need super-duper fast JSON in your app, use the YAJL gem and simply `require 'yajl/json_gem'` for full compatibility (though Ruby's JSON is now faster then the YAJL readme declares).
