### PR TITLE
Add support for 'around' callbacks and conditionals using proper chain

### DIFF
--- a/lib/crepe.rb
+++ b/lib/crepe.rb
@@ -8,6 +8,7 @@ module Crepe
 
   autoload :Accept,     'crepe/accept'
   autoload :API,        'crepe/api'
+  autoload :Callbacks,  'crepe/callbacks'
   autoload :Config,     'crepe/config'
   autoload :Endpoint,   'crepe/endpoint'
   autoload :Filter,     'crepe/filter'

--- a/lib/crepe/callbacks.rb
+++ b/lib/crepe/callbacks.rb
@@ -1,0 +1,123 @@
+require 'thread'
+
+module Crepe
+  # A simple callback system similar to ActiveSupport::Callbacks.
+  # Handles 'before', 'around' and 'after' callbacks.
+  module Callbacks
+
+    # A callback chain that compiles the given callbacks into a chain around
+    # the method name given.
+    class Chain
+
+      attr_reader :name, :callbacks, :block
+
+      def initialize name, callbacks = [], &block
+        @name, @callbacks, @block, @mutex = name, callbacks, block, Mutex.new
+      end
+
+      # Calls the callbacks before, around and after calling the method 'name'
+      # on the given target.
+      #
+      # return [void]
+      delegate :call, to: :compiled
+
+      private
+
+      def compiled
+        @compiled || @mutex.synchronize do
+          @compiled ||= normalized.inject(final) do |chain, callback|
+            callback.apply chain
+          end
+        end
+      end
+
+      def final
+        block, name = @block, @name
+        ->(target) { block ? block.call : target.send(name) }
+      end
+
+      def normalized
+        chain = @callbacks.map do |cb|
+          cb.is_a?(Callback) ? cb : Callback.new(@name, *cb)
+        end
+
+        before, after = *chain.partition { |cb| cb.kind != :after }
+        before.reverse + after
+      end
+
+    end
+
+    # A wrapper around a filter such as a symbol or proc that allows it to be
+    # chained with other callbacks and called against the intended target.
+    class Callback
+
+      attr_reader :name, :kind, :filter
+
+      def initialize name, kind = :before, filter = name, options = {}
+        @name, @kind, @filter, @options = name, kind, filter, options
+      end
+
+      def apply chain
+        callback = to_proc
+        cond = conditions_procs
+        cond = false if cond.empty?
+
+        case kind
+        when :before
+          ->(target) {
+            callback.call target if !cond || cond.all? { |c| c.call target }
+            chain.call target
+          }
+        when :around
+          ->(target) {
+            if cond && !cond.all? { |c| c.call target }
+              next chain.call target
+            end
+            callback.call(target) { chain.call target }
+          }
+        when :after
+          ->(target) {
+            chain.call target
+            callback.call target if !cond || cond.all? { |c| c.call target }
+          }
+        end
+      end
+
+      def conditions_procs
+        if_procs = Array(@options[:if]).map { |filter| make_proc filter }
+
+        unless_procs = Array(@options[:unless]).map do |filter|
+          uninverted = make_proc filter
+          ->(*args, &blk) { !uninverted.call(*args, &blk) }
+        end
+
+        if_procs + unless_procs
+      end
+
+      def make_proc filter
+        filter = eval "-> { #{filter} }" if filter.is_a?(String)
+        case
+        when filter.is_a?(Symbol)
+          ->(target, &blk) { target.send filter, &blk }
+        when filter.is_a?(Proc)
+          if filter.arity.zero?
+            ->(target, &blk) { target.instance_exec(&filter) }
+          else
+            ->(target, &blk) { target.instance_exec blk, &filter }
+          end
+        when filter.respond_to?(:filter)
+          ->(target, &blk) { filter.filter target, &blk }
+        else
+          name, kind = @name, @kind
+          ->(target, &blk) { filter.send "#{kind}_#{name}", target, &blk }
+        end
+      end
+
+      def to_proc
+        make_proc @filter
+      end
+
+    end
+
+  end
+end

--- a/lib/crepe/endpoint.rb
+++ b/lib/crepe/endpoint.rb
@@ -13,7 +13,9 @@ module Crepe
 
       def default_config
         @default_config ||= {
-          callbacks: {},
+          callbacks: [
+            [:before, :ensure_acceptable]
+          ],
           formats: [:json],
           parsers: Hash.new(Parser::Simple),
           renderers: Hash.new(Renderer::Simple),
@@ -46,9 +48,10 @@ module Crepe
     def configure! new_config
       @config ||= self.class.default_config
       @config = Util.deep_merge config, new_config
-      if config[:formats].empty?
-        raise ArgumentError, 'wrong number of formats (at least 1)'
-      end
+
+      @handle_request_chain = Callbacks::Chain.new(
+        :handle_request, config[:callbacks]
+      )
     end
 
     # Rack call interface.
@@ -122,7 +125,7 @@ module Crepe
     # @note Called automatically before an endpoint executes.
     # @return [void]
     # @see API.parse
-    def parse body, options = {}
+    def parse body
       request.body = parser.parse body
       @params = params.merge request.body if request.body.is_a? Hash
     end
@@ -226,28 +229,30 @@ module Crepe
 
         halt = catch :halt do
           begin
-            not_acceptable! unless format
-            parse request.body if request.body.present?
-            run_callbacks :before
-            payload = _run_handler
-            render payload if payload && response.body.nil?
+            handle_request_chain.call self
             nil
           rescue => e
             handle_exception e
           end
         end
         render halt if halt
-        run_callbacks :after
 
         response.finish
       end
 
+      attr_reader :handle_request_chain
+
     private
 
-      def run_callbacks type
-        config[:callbacks][type].each do |c|
-          c.respond_to?(:filter) ? c.filter(self) : instance_eval(&c)
-        end
+      def ensure_acceptable
+        not_acceptable! unless format
+      end
+
+      def handle_request
+        parse request.body if request.body.present?
+        payload = _run_handler
+        render payload if payload && response.body.nil?
+        payload
       end
 
       def handle_exception exception

--- a/spec/crepe/callbacks_spec.rb
+++ b/spec/crepe/callbacks_spec.rb
@@ -9,6 +9,27 @@ describe Crepe::Endpoint, 'callbacks' do
       end
     end
 
+    before   { @variable = '' }
+    namespace :around do
+      around do |handle|
+        @variable << 'before1'
+        result = handle.call;
+        response.body = nil;
+        render result + ' after1'
+      end
+
+      around do |handle|
+        @variable << ' before2'
+        result = handle.call;
+        response.body = nil;
+        result + ' after2'
+      end
+
+      get do
+        "#{@variable} during"
+      end
+    end
+
     namespace :after do
       after { response.body = nil; render 'after' }
       get do
@@ -16,26 +37,76 @@ describe Crepe::Endpoint, 'callbacks' do
       end
     end
 
-    before   { @variable = '1' }
     namespace :many do
-      before { @variable << '2' }
-      after  { @variable << '3' }
+      before { @variable << '1' }
+      around { |handler|
+        @variable << '2'
+        @variable << handler.call
+        @variable << '3'
+      }
+      after  { @variable << '4' }
       after  { response.body = nil; render @variable }
+
       get do
         'during'
+      end
+    end
+
+    namespace :conditional do
+      let(:always)    { true }
+      let(:never)     { false }
+      let(:sometimes) { request.params.key? 'on' }
+
+      before(if: :always)    { @variable << '1' }
+      before(if: :never)     { @variable << '2' }
+      around(if: :sometimes) { |handler|
+        @variable << '3'
+        @variable << handler.call
+        @variable << '4'
+      }
+      after(unless: :never)  { @variable << '5' }
+      after(unless: :always) { @variable << '6' }
+      after { response.body = nil; render @variable }
+
+      get do
+        'during'
+      end
+
+      namespace :string do
+        before(if:     "request.params.key? 'on' ") { @variable << 'on' }
+        before(unless: "request.params.key? 'on' ") { @variable << 'off' }
+        after { response.body = nil; render @variable }
+
+        get do
+          'during'
+        end
       end
     end
   end
 
   it 'runs before endpoint handlers' do
-    get('/before').body.should include 'before'
+    get('/before').body.should eq '"before"'
+  end
+
+  it 'runs around endpoint handlers' do
+    get('/around').body.should eq '"before1 before2 during after2 after1"'
   end
 
   it 'runs after endpoint handlers' do
-    get('/after').body.should include 'after'
+    get('/after').body.should eq '"after"'
   end
 
   it 'runs series of callbacks' do
-    get('/many').body.should include '123'
+    get('/many').body.should eq '"12during34"'
+  end
+
+  it 'runs series of callbacks only when conditions match' do
+    get('/conditional').body.should eq '"15"'
+    get('/conditional?on').body.should eq '"13during45"'
+  end
+
+  it 'evaluates string conditions with endpoint binding' do
+    get('/conditional/string').body.should eq '"1off5"'
+    get('/conditional/string?on').body.should eq '"13onduring45"'
   end
 end


### PR DESCRIPTION
Middleware isn't always sufficient if you need access to endpoint values, e.g. parsed version and content-type. The 'around' filter is much more complex to implement, but the result is extremely flexible.

This brings Crepe callbacks much closer to ActiveSupport::Callbacks, without much of the complexity and compatibility issues that will come with actually using ActiveSupport::Callbacks. AS callbacks are stored
in class variables, meaning we can't have different chains for each endpoint instance, and we can't use the underlying AS classes because AS 4.1 rewrites the Callbacks implementation completely.

This does increase the stack depth significantly, so we'll probably want to do some benchmarks to make sure this isn't slowing things down unacceptably.
