### PR TITLE
Terminate streaming endpoints with an empty chunk

### DIFF
--- a/lib/crepe/streaming.rb
+++ b/lib/crepe/streaming.rb
@@ -24,6 +24,10 @@ module Crepe
         write "#{data.chomp}\n"
       end
 
+      def close
+        write ''
+        super
+      end
     end
 
     class << self
@@ -69,7 +73,7 @@ module Crepe
               begin
                 run_callbacks :after_stream
               ensure
-                io.close
+                @stream.close
               end
             end
           end


### PR DESCRIPTION
HTTP Streams must be terminated by an empty chunk, or certain clients
will raise errors. For example, trying to `curl` a streaming endpoint
will finish with:

`curl: (18) transfer closed with outstanding read data remaining`

Ensure that streaming endpoints write an empty chunk, denoted by
`0\r\n\r\n` before closing.

Signed-off-by: David Celis me@davidcel.is
