### PR TITLE
Update development dependencies

### DIFF
--- a/crepe.gemspec
+++ b/crepe.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack',          '~> 1.5.x'
   s.add_dependency 'rack-mount',    '~> 0.8.x'
 
-  s.add_development_dependency 'cane',       '~> 2.3.x'
-  s.add_development_dependency 'rake',       '~> 10.0.x'
-  s.add_development_dependency 'rspec',      '~> 2.13.x'
+  s.add_development_dependency 'cane',       '~> 2.6.x'
+  s.add_development_dependency 'rake',       '~> 10.3.x'
+  s.add_development_dependency 'rspec',      '~> 3.0.x'
   s.add_development_dependency 'rack-test',  '~> 0.6.x'
   s.add_development_dependency 'yard',       '~> 0.8.x'
 end

--- a/spec/crepe/acceptance_spec.rb
+++ b/spec/crepe/acceptance_spec.rb
@@ -11,10 +11,9 @@ describe Crepe::Endpoint, 'acceptance' do
 
   context 'unacceptable content' do
     it 'renders Not Acceptable' do
-      get '/.xml'
-      last_response.body.should eq(JSON.dump(
+      expect(get('/.xml').body).to eq JSON.dump(
         error: { message: 'Not Acceptable', accepts: ['application/json'] }
-      ))
+      )
     end
   end
 end

--- a/spec/crepe/basic_auth_spec.rb
+++ b/spec/crepe/basic_auth_spec.rb
@@ -22,20 +22,20 @@ describe Crepe::API, '.basic_auth' do
   end
 
   it "doesn't apply outside scopes" do
-    get('/').should be_ok
+    expect(get '/').to be_ok
   end
 
   it "denies access" do
-    get('/admin').status.should eq 401
+    expect(get('/admin').status).to eq 401
   end
 
   it "accepts valid credentials" do
     basic_authorize 'admin', 'secret'
-    get('/admin').should be_ok
+    expect(get '/admin').to be_ok
   end
 
   it "accepts nested credentials" do
     basic_authorize 'root', '53cr37'
-    get('/admin/sudo').should be_ok
+    expect(get '/admin/sudo').to be_ok
   end
 end

--- a/spec/crepe/callbacks_spec.rb
+++ b/spec/crepe/callbacks_spec.rb
@@ -28,14 +28,14 @@ describe Crepe::Endpoint, 'callbacks' do
   end
 
   it 'runs before endpoint handlers' do
-    get('/before').body.should include 'before'
+    expect(get('/before').body).to include 'before'
   end
 
   it 'runs after endpoint handlers' do
-    get('/after').body.should include 'after'
+    expect(get('/after').body).to include 'after'
   end
 
   it 'runs series of callbacks' do
-    get('/many').body.should include '123'
+    expect(get('/many').body).to include '123'
   end
 end

--- a/spec/crepe/helper_spec.rb
+++ b/spec/crepe/helper_spec.rb
@@ -50,19 +50,20 @@ describe Crepe::API, '.helper' do
   end
 
   it 'extends endpoints with block methods' do
-    get('/block').body.should include 'block'
+    expect(get('/block').body).to include 'block'
   end
 
   it 'extends endpoints with module methods' do
-    get('/module').body.should include 'module'
+    expect(get('/module').body).to include 'module'
   end
 
   it 'extends nested endpoints with outer and inner helpers' do
-    get('/module/nest').body.should include 'module and block'
-    get('/module/nest').body.should include 'body'
+    expect(get('/module/nest').body).to include 'module and block'
+    expect(get('/module/nest').body).to include 'body'
   end
 
   it 'does not extend outer endpoints with inner helpers' do
-    get('/').body.should include "undefined local variable or method `name'"
+    message = "undefined local variable or method `name'"
+    expect(get('/').body).to include message
   end
 end

--- a/spec/crepe/http_methods_spec.rb
+++ b/spec/crepe/http_methods_spec.rb
@@ -18,30 +18,31 @@ describe Crepe::API, 'HTTP methods' do
   methods.each do |method|
     describe ".#{method}" do
       it "routes #{method.upcase} requests" do
-        send(method, "/method/#{method}").should be_successful
+        expect(send method, "/method/#{method}").to be_successful
       end
 
       if method == 'get'
         it "routes HEAD requests" do
-          head("/method/#{method}").should be_successful
+          expect(head "/method/#{method}").to be_successful
         end
       else
         it "does not route HEAD requests" do
-          head("/method/#{method}").should be_method_not_allowed
+          expect(head "/method/#{method}").to be_method_not_allowed
         end
       end
 
       it "routes OPTIONS requests" do
-        options("/method/#{method}").should be_successful
+        expect(options "/method/#{method}").to be_successful
       end
 
       it "routes OPTIONS requests other formats" do
-        options("/method/#{method}.html").should be_successful
+        expect(options "/method/#{method}.html").to be_successful
       end
 
       it "does not route anything else" do
         (methods - [method]).each do |other_method|
-          send(other_method, "/method/#{method}").should be_method_not_allowed
+          send(other_method, "/method/#{method}")
+          expect(last_response).to be_method_not_allowed
         end
       end
     end
@@ -50,7 +51,7 @@ describe Crepe::API, 'HTTP methods' do
   describe ".any" do
     it "routes anything" do
       (methods + %w[head options]).each do |method|
-        send(method, '/method/any').should be_successful
+        expect(send method, '/method/any').to be_successful
       end
     end
   end

--- a/spec/crepe/js_callback_spec.rb
+++ b/spec/crepe/js_callback_spec.rb
@@ -11,7 +11,7 @@ describe Crepe::Middleware::JSCallback do
   before { get '/anywhere', callback: 'say' }
 
   it 'renders JavaScript callback' do
-    last_response.body.should eq(
+    expect(last_response.body).to eq(
       '%{function}(%{body},%{headers},%{status})' % {
         function: 'say',
         body: { error: { message: 'Not Found' } }.to_json,
@@ -25,12 +25,12 @@ describe Crepe::Middleware::JSCallback do
   end
 
   it 'renders 200 OK' do
-    last_response.status.should eq 200
+    expect(last_response).to be_ok
   end
 
   it 'renders application/javascript' do
     content_type = last_response.headers['Content-Type']
-    content_type.should eq 'application/javascript; charset=utf-8'
+    expect(content_type).to eq 'application/javascript; charset=utf-8'
   end
 
   context 'with a custom callback param' do
@@ -44,7 +44,9 @@ describe Crepe::Middleware::JSCallback do
     end
 
     it 'renders the callback param' do
-      get('/', jsonp: 'say').body.should eq(
+      get '/', jsonp: 'say'
+
+      expect(last_response.body).to eq(
         '%{function}(%{body},%{headers},%{status})' % {
           function: 'say',
           body: { hello: 'world' }.to_json,

--- a/spec/crepe/let_spec.rb
+++ b/spec/crepe/let_spec.rb
@@ -21,7 +21,7 @@ describe Crepe::API do
     end
 
     it 'memoizes the return value' do
-      get('/').body.should eq '{"once":[1,1,1],"many":[1,2,3]}'
+      expect(get('/').body).to eq '{"once":[1,1,1],"many":[1,2,3]}'
     end
 
     context 'with block arguments' do
@@ -37,7 +37,7 @@ describe Crepe::API do
       end
 
       it 'memoizes depending on input' do
-        get('/1').body.should eq '{"n + 1":2,"n + 2":3,"n + 3":4}'
+        expect(get('/1').body).to eq '{"n + 1":2,"n + 2":3,"n + 3":4}'
       end
     end
   end
@@ -54,7 +54,7 @@ describe Crepe::API do
     end
 
     it 'invokes the helper before the handler' do
-      get('/').body.should eq '{"logged_in":true}'
+      expect(get('/').body).to eq '{"logged_in":true}'
     end
   end
 end

--- a/spec/crepe/middleware_spec.rb
+++ b/spec/crepe/middleware_spec.rb
@@ -19,8 +19,8 @@ describe Crepe::API, "middleware" do
   end
 
   it "runs in the stack" do
-    get('/').headers.should include 'X-Count'
-    get('/api').headers.should include 'X-Count'
+    expect(get('/').headers).to    include 'X-Count'
+    expect(get('/api').headers).to include 'X-Count'
   end
 
   describe "arguments" do
@@ -29,7 +29,7 @@ describe Crepe::API, "middleware" do
     end
 
     it "accepts arguments and block" do
-      get('/').body.should eq '123'
+      expect(get('/').body).to eq '123'
     end
   end
 
@@ -38,7 +38,7 @@ describe Crepe::API, "middleware" do
     let(:app) { api(base) { get } }
 
     it "uses middleware from the superclass" do
-      get('/').headers.should include 'X-Count'
+      expect(get('/').headers).to include 'X-Count'
     end
   end
 
@@ -47,7 +47,7 @@ describe Crepe::API, "middleware" do
       app { scope(:api) { use middleware } }
 
       it "raises an exception" do
-        expect { app }.to raise_error ArgumentError
+        expect { app }.to raise_error
       end
     end
 
@@ -59,11 +59,11 @@ describe Crepe::API, "middleware" do
       end
 
       it "uses middleware within mount namespace" do
-        get('/api1').headers.should include 'X-Count'
+        expect(get('/api1').headers).to include 'X-Count'
       end
 
       it "doesn't use middleware outside mount namespace" do
-        get('/').headers.should_not include 'X-Count'
+        expect(get('/').headers).not_to include 'X-Count'
       end
 
       context "with duplicate middleware" do
@@ -75,7 +75,7 @@ describe Crepe::API, "middleware" do
           end
 
           it "is not used again" do
-            get('/api1/api2/api3').headers['X-Count'].should eq 1
+            expect(get('/api1/api2/api3').headers['X-Count']).to eq 1
           end
         end
 
@@ -87,7 +87,7 @@ describe Crepe::API, "middleware" do
           end
 
           it "is used in mounted endpoints" do
-            get('/api1/api2/api3').headers['X-Count'].should eq 3
+            expect(get('/api1/api2/api3').headers['X-Count']).to eq 3
           end
         end
 

--- a/spec/crepe/mount_spec.rb
+++ b/spec/crepe/mount_spec.rb
@@ -16,14 +16,14 @@ describe Crepe::API, '.mount' do
   end
 
   it 'mounts Rack apps in place' do
-    get('/').body.should eq '"HI"'
+    expect(get('/').body).to eq '"HI"'
   end
 
   it 'mounts Rack apps at paths' do
-    get('/ping').body.should eq 'OK'
+    expect(get('/ping').body).to eq 'OK'
   end
 
   it 'mounts Rack apps within namespaces' do
-    get('/pong').body.should eq 'KO'
+    expect(get('/pong').body).to eq 'KO'
   end
 end

--- a/spec/crepe/paths_spec.rb
+++ b/spec/crepe/paths_spec.rb
@@ -32,17 +32,17 @@ describe Crepe::API, 'paths' do
   end
 
   it "routes known paths" do
-    get('/v2/users').should be_successful
-    get('/v2/users/1').should be_successful
-    get('/v2/users/1/posts').should be_successful
-    get('/v1/users/all').should be_successful
-    get('/v1/users/1').should be_successful
-    get('/v1/users/1/posts').body.should include 'active'
+    expect(get '/v2/users').to be_successful
+    expect(get '/v2/users/1').to be_successful
+    expect(get '/v2/users/1/posts').to be_successful
+    expect(get '/v1/users/all').to be_successful
+    expect(get '/v1/users/1').to be_successful
+    expect(get('/v1/users/1/posts').body).to include 'active'
   end
 
   it "doesn't route unknown paths" do
-    get('/').should be_not_found
-    get('/v2/users/all').should be_not_found
-    get('/v1/users/none').should be_not_found
+    expect(get '/').to be_not_found
+    expect(get '/v2/users/all').to be_not_found
+    expect(get '/v1/users/none').to be_not_found
   end
 end

--- a/spec/crepe/rescue_from_spec.rb
+++ b/spec/crepe/rescue_from_spec.rb
@@ -41,25 +41,25 @@ describe Crepe::API, ".rescue_from" do
 
   it "rescues with a block" do
     get '/'
-    last_response.should be_bad_request
-    last_response.body.should include 'Time to run!'
+    expect(last_response).to be_bad_request
+    expect(last_response.body).to include 'Time to run!'
   end
 
   it "rescues with a handler without an argument" do
     get '/errors/argument'
-    last_response.status.should eq 422
-    last_response.body.should include 'Unprocessable Entity'
+    expect(last_response.status).to eq 422
+    expect(last_response.body).to include 'Unprocessable Entity'
   end
 
   it "rescues with a handler with an argument" do
     get '/errors/standard'
-    last_response.should be_forbidden
-    last_response.body.should include 'Nothing to see here, folks.'
+    expect(last_response).to be_forbidden
+    expect(last_response.body).to include 'Nothing to see here, folks.'
   end
 
   it "rescues with the most specific exception available" do
     get '/errors/runtime'
-    last_response.should be_bad_request
-    last_response.body.should include 'Run away! Run away!'
+    expect(last_response).to be_bad_request
+    expect(last_response.body).to include 'Run away! Run away!'
   end
 end

--- a/spec/crepe/restful_status_spec.rb
+++ b/spec/crepe/restful_status_spec.rb
@@ -23,20 +23,20 @@ describe Crepe::API, 'RESTful status' do
   %w[post put patch delete].each do |method|
     if method == 'post'
       it "returns 201 Created for POST with content" do
-        post('/post').status.should eq 201
+        expect(post('/post').status).to eq 201
       end
     else
       it "returns 200 OK for #{method.upcase} with content" do
-        send(method, "/#{method}").status.should eq 200
+        expect(send(method, "/#{method}").status).to eq 200
       end
     end
 
     it "returns 204 No Content for #{method.upcase} without content" do
-      send(method, "/empty/#{method}").status.should eq 204
+      expect(send(method, "/empty/#{method}").status).to eq 204
     end
 
     it "returns the original status for #{method.upcase} if set explicitly" do
-      send(method, "/explicit/#{method}").status.should eq 202
+      expect(send(method, "/explicit/#{method}").status).to eq 202
     end
   end
 end

--- a/spec/crepe/url_for_spec.rb
+++ b/spec/crepe/url_for_spec.rb
@@ -8,40 +8,40 @@ describe Crepe::Helper::URLFor, '#url_for' do
     get { url }
   end
 
-  subject { get('/').body }
+  subject(:response) { get('/').body }
 
   it 'joins components' do
     app.let(:url) { url_for :hello, :world }
-    should eq 'http://example.org/hello/world'
+    expect(response).to eq 'http://example.org/hello/world'
   end
 
   it 'parameterizes objects' do
     app.let(:user) { Object.new.tap { |o| def o.to_param() 1 end } }
     app.let(:url) { url_for :users, user }
-    should eq 'http://example.org/users/1'
+    expect(response).to eq 'http://example.org/users/1'
   end
 
   it 'normalizes the path' do
     app.let(:url) { url_for '/one', nil, '/two/', '//three///' }
-    should eq 'http://example.org/one/two/three'
+    expect(response).to eq 'http://example.org/one/two/three'
   end
 
   it 'appends an extension' do
     app.let(:url) { url_for :index, format: :html }
-    should eq 'http://example.org/index.html'
+    expect(response).to eq 'http://example.org/index.html'
   end
 
   it 'appends a query' do
     app.let(:url) { url_for hello: 'world' }
-    should eq 'http://example.org/?hello=world'
+    expect(response).to eq 'http://example.org/?hello=world'
   end
 
   context 'requested with an extension' do
-    subject { get('/.txt').body }
+    subject(:response) { get('/.txt').body }
 
     it 'appends an extension' do
       app.let(:url) { url_for :robots }
-      should eq 'http://example.org/robots.txt'
+      expect(response).to eq 'http://example.org/robots.txt'
     end
   end
 

--- a/spec/crepe/versioning_spec.rb
+++ b/spec/crepe/versioning_spec.rb
@@ -10,7 +10,7 @@ describe Crepe::API, 'versioning' do
     end
 
     it 'routes with the path' do
-      get('/v1').should be_ok
+      expect(get '/v1').to be_ok
     end
   end
 
@@ -29,14 +29,13 @@ describe Crepe::API, 'versioning' do
 
     it 'routes to several versions at the same path' do
       get '/', {}, 'HTTP_ACCEPT' => 'application/vnd.pancake-v2+json'
-      last_response.body.should include 'v2'
+      expect(last_response.body).to include 'v2'
       get '/', {}, 'HTTP_ACCEPT' => 'application/vnd.pancake-v1+json'
-      last_response.body.should include 'v1'
+      expect(last_response.body).to include 'v1'
     end
 
     it 'defaults to the specified version' do
-      get '/'
-      last_response.body.should include 'v2'
+      expect(get('/').body).to include 'v2'
     end
   end
 
@@ -54,12 +53,12 @@ describe Crepe::API, 'versioning' do
     end
 
     it 'routes to the version with a parameter' do
-      get('/', ver: 'v2').body.should include 'v2'
-      get('/', ver: 'v1').body.should include 'v1'
+      expect(get('/', ver: 'v2').body).to include 'v2'
+      expect(get('/', ver: 'v1').body).to include 'v1'
     end
 
     it 'defaults to the first specified version' do
-      get('/').body.should include 'v1'
+      expect(get('/').body).to include 'v1'
     end
   end
 

--- a/spec/lib/crepe/api_spec.rb
+++ b/spec/lib/crepe/api_spec.rb
@@ -6,7 +6,7 @@ describe Crepe::API do
   describe '.param' do
     app { param(:action) { get { params[:action] } } }
     it 'wraps endpoints with a param-based path component' do
-      get('/dig').body.should include 'dig'
+      expect(get('/dig').body).to include 'dig'
     end
   end
 

--- a/spec/lib/crepe/endpoint_spec.rb
+++ b/spec/lib/crepe/endpoint_spec.rb
@@ -19,12 +19,12 @@ describe Crepe::Endpoint do
 
     context 'with formats configured' do
       let(:config) { { formats: [:xml, :json] } }
-      it { should eq :xml }
+      it { is_expected.to eq :xml }
     end
 
     context 'with a format parameter' do
       before { env['QUERY_STRING'] = 'format=json' }
-      it { should eq :json }
+      it { is_expected.to eq :json }
     end
   end
 
@@ -32,7 +32,7 @@ describe Crepe::Endpoint do
     let(:handler) { proc { headers['Awesome'] = 'You are awesome!' } }
 
     it 'become response headers' do
-      response.headers.should include 'Awesome'=>'You are awesome!'
+      expect(response.headers).to include 'Awesome' => 'You are awesome!'
     end
   end
 
@@ -40,11 +40,11 @@ describe Crepe::Endpoint do
     let(:handler) { proc { error! 404, 'Not found' } }
 
     it 'sets status code' do
-      response.status.should eq 404
+      expect(response.status).to eq 404
     end
 
     it 'sets message' do
-      response.body.should include 'Not found'
+      expect(response.body).to include 'Not found'
     end
   end
 
@@ -52,19 +52,20 @@ describe Crepe::Endpoint do
     let(:handler) { proc { unauthorized! realm: 'Crepe' } }
 
     it 'returns 401 Unauthorized' do
-      response.status.should eq 401
-      response.body.should eq '{"error":{"message":"Unauthorized"}}'
+      expect(response.status).to eq 401
+      expect(response.body).to eq '{"error":{"message":"Unauthorized"}}'
     end
 
     it 'sets WWW-Authenticate header' do
-      response.headers.should include 'WWW-Authenticate'=>'Basic realm="Crepe"'
+      header = { 'WWW-Authenticate' => 'Basic realm="Crepe"' }
+      expect(response.headers).to include header
     end
 
     context 'with a message' do
       let(:handler) { proc { unauthorized! 'Not Allowed', realm: 'Crepe' } }
 
       it 'returns the specified error message' do
-        response.body.should eq '{"error":{"message":"Not Allowed"}}'
+        expect(response.body).to eq '{"error":{"message":"Not Allowed"}}'
       end
     end
 
@@ -73,7 +74,7 @@ describe Crepe::Endpoint do
 
       it 'returns the data' do
         json = '{"error":{"message":"Unauthorized","extra":"data"}}'
-        response.body.should eq json
+        expect(response.body).to eq json
       end
     end
   end

--- a/spec/lib/crepe/middleware/head_spec.rb
+++ b/spec/lib/crepe/middleware/head_spec.rb
@@ -8,11 +8,11 @@ describe Crepe::Middleware::Head do
     before { head '/' }
 
     it 'sends as a GET request' do
-      last_request.should be_get
+      expect(last_request).to be_get
     end
 
     it 'returns no content' do
-      last_response.body.should be_empty
+      expect(last_response.body).to be_empty
     end
   end
 
@@ -21,11 +21,11 @@ describe Crepe::Middleware::Head do
       before { send method.downcase, '/' }
 
       it "sends as a #{method} request" do
-        last_request.request_method.should eq method
+        expect(last_request.request_method).to eq method
       end
 
       it 'returns content' do
-        last_response.body.should_not be_empty
+        expect(last_response.body).not_to be_empty
       end
     end
   end

--- a/spec/lib/crepe/params_spec.rb
+++ b/spec/lib/crepe/params_spec.rb
@@ -8,16 +8,12 @@ describe Crepe::Params do
     context 'with a present key' do
       it 'returns its value' do
         input[:key] = {'hello'=>'world'}
-        params.require(:key).should eq(input[:key])
+        expect(params.require :key).to eq(input[:key])
       end
     end
 
     context 'with a missing key' do
-      it {
-        expect { params.require :missing }.to raise_error(
-          Crepe::Params::Missing
-        )
-      }
+      it { expect { params.require :missing }.to raise_error }
     end
   end
 
@@ -27,26 +23,24 @@ describe Crepe::Params do
       let(:permitted) { params.permit :secure_key }
 
       it { expect(permitted).to be_permitted }
+
       it 'permits post-dup' do
         expect(permitted.dup).to be_permitted
       end
+
       it 'returns itself' do
-        permitted.should eq params
+        expect(permitted).to eq params
       end
     end
 
     context 'with an insecure key' do
       let(:input) { { permitted: 1 } }
 
-      it { expect(params).to_not be_permitted }
-      it {
-        expect { params.permit :invalid }.to raise_error(
-          Crepe::Params::Invalid
-        )
-      }
+      it { expect(params).not_to be_permitted }
+      it { expect { params.permit :invalid }.to raise_error }
     end
   end
 
-  it { should respond_to :permitted? }
-  it { should be_frozen }
+  it { is_expected.to respond_to :permitted? }
+  it { is_expected.to be_frozen }
 end

--- a/spec/lib/crepe/renderer/pagination_spec.rb
+++ b/spec/lib/crepe/renderer/pagination_spec.rb
@@ -11,7 +11,7 @@ describe Crepe::Renderer::Pagination::Links do
               '<http://example.com/search?page=6>; rel="last"'].join(', ')
 
     links = described_class.new request, 1, 10, 55
-    links.render.should == header
+    expect(links.render).to eq header
   end
 
   it "renders the second of multiple pages" do
@@ -21,7 +21,7 @@ describe Crepe::Renderer::Pagination::Links do
               '<http://example.com/search?page=6>; rel="last"'].join(', ')
 
     links = described_class.new request, 2, 10, 55
-    links.render.should == header
+    expect(links.render).to eq header
   end
 
   it "renders the third of multiple pages" do
@@ -31,7 +31,7 @@ describe Crepe::Renderer::Pagination::Links do
               '<http://example.com/search?page=6>; rel="last"'].join(', ')
 
     links = described_class.new request, 3, 10, 55
-    links.render.should == header
+    expect(links.render).to eq header
   end
 
   it "renders the last page" do
@@ -39,6 +39,6 @@ describe Crepe::Renderer::Pagination::Links do
               '<http://example.com/search?page=5>; rel="prev"'].join(', ')
 
     links = described_class.new request, 6, 10, 55
-    links.render.should == header
+    expect(links.render).to eq header
   end
 end

--- a/spec/lib/crepe/renderer/simple_spec.rb
+++ b/spec/lib/crepe/renderer/simple_spec.rb
@@ -5,7 +5,9 @@ describe Crepe::Renderer::Simple do
 
   let(:endpoint) do
     Crepe::Endpoint.new{}.tap do |ep|
-      ep.stub request: Crepe::Request.new(Rack::MockRequest.env_for)
+      allow(ep).to receive(:request) do
+        Crepe::Request.new(Rack::MockRequest.env_for)
+      end
     end
   end
   let(:renderer) { described_class.new(endpoint) }
@@ -13,17 +15,17 @@ describe Crepe::Renderer::Simple do
 
   it "renders string from simple hashes" do
     resource = { test: 1234 }
-    renderer.render(resource, format: :text).should == '{:test=>1234}'
+    expect(renderer.render resource, format: :text).to eq '{:test=>1234}'
   end
 
   it "renders json from simple hashes" do
     resource = { test: 1234 }
-    renderer.render(resource, format: :json).should == '{"test":1234}'
+    expect(renderer.render resource, format: :json).to eq '{"test":1234}'
   end
 
   it "renders json from objects responding to #as_json" do
     resource = Struct.new(:as_json).new test: 1234
-    renderer.render(resource, format: :json).should == '{"test":1234}'
+    expect(renderer.render resource, format: :json).to eq '{"test":1234}'
   end
 
 end

--- a/spec/lib/crepe/request_spec.rb
+++ b/spec/lib/crepe/request_spec.rb
@@ -10,7 +10,7 @@ describe Crepe::Request do
   describe '#headers' do
     it 'indexes with human-readable header keys' do
       env['HTTP_IF_NONE_MATCH'] = '"ETag!"'
-      request.headers['If-None-Match'].should eq '"ETag!"'
+      expect(request.headers['If-None-Match']).to eq '"ETag!"'
     end
   end
 
@@ -20,27 +20,28 @@ describe Crepe::Request do
       env['crepe.original_request_method'] = 'HEAD'
     end
 
-    it { should be_head }
-    it { should be_get }
+    it { is_expected.to be_head }
+    it { is_expected.to be_get }
 
     context 'method' do
       subject { request.method }
-      it { should eq 'HEAD' }
+      it { is_expected.to eq 'HEAD' }
     end
   end
 
   describe '#params' do
     it 'merges GET, POST, and path parameters' do
-      request.stub GET: {'get'=>'true'}
-      request.stub POST: {'post'=>'true'}
-      request.env['rack.routing_args'] = {'path'=>'true'}
-      request.params.should eq('get'=>'true', 'post'=>'true', 'path'=>'true')
+      allow(request).to receive(:GET).and_return 'get' => 'true'
+      allow(request).to receive(:POST).and_return 'post'=> 'true'
+      request.env['rack.routing_args'] = { 'path' => 'true' }
+      params = { 'get' => 'true', 'post' => 'true', 'path' => 'true' }
+      expect(request.params).to eq(params)
     end
   end
 
   describe '#credentials' do
     it 'returns an array without credentials' do
-      request.credentials.should be_empty
+      expect(request.credentials).to be_empty
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,11 @@ require 'crepe'
 RSpec.configure do |config|
   config.include Rack::Test::Methods
 
+  config.expect_with :rspec do |expectations|
+    # Enable only the newer, non-monkey-patching expect syntax.
+    expectations.syntax = :expect
+  end
+
   def api base = Crepe::API, &block
     Class.new base, &block
   end


### PR DESCRIPTION
Update RSpec to version 3. This deprecates the old, monkey-patching
`should` syntax in favor of the newer `expect` syntax, which all of
Crepe's specs have been updated to use.

Additionally, update Cane and Rake.

Signed-off-by: David Celis me@davidcel.is
