### PR TITLE
Fix Crepe::Params#respond_to?

### DIFF
--- a/lib/crepe/params.rb
+++ b/lib/crepe/params.rb
@@ -79,7 +79,10 @@ module Crepe
     end
 
     def respond_to? method_name, include_private = false
-      INSTANCE_METHODS.include? method_name or super
+      this_responds = INSTANCE_METHODS.include? method_name
+      hash_responds = @params.respond_to? method_name, include_private
+
+      this_responds or hash_responds
     end
 
     def to_hash


### PR DESCRIPTION
Crepe::Params instances respond to more than we're saying. In
method_missing, we'll proxy any method call through to the underlying
HashWithIndifferentAccess. In respond_to?, we claim that a Crepe::Params
instance will only respond to require, permit, permitted?, permit!, and
instance methods present on BasicObject. We should change the `super`
check to a check that the underlying HashWithIndifferentAccess responds
to the method.

Signed-off-by: David Celis me@davidcel.is
