### PR TITLE
Allow routing to arbitrary Rack applications

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -95,13 +95,22 @@ module Crepe
       #     # ...
       #   end
       #
-      # @return [Endpoint]
+      # You can also route to arbitrary Rack applications:
+      #
+      #   get RackApp
+      #   get '/path', to: RackApp
+      #
+      # @return [Object#call]
       # @todo
       #   Examples of the other options.
       def route method, path = '/', **options, &block
-        endpoint = Class.new(Endpoint) { handle(block || proc { head }) }
-        mount endpoint, options.merge(at: path, method: method, anchor: true)
-        endpoint
+        app, path = path, '/' if path.respond_to?(:call)
+        app ||= options.delete(:to) do
+          Class.new(Endpoint) { handle block || -> { head } }
+        end
+
+        mount app, options.merge(at: path, method: method, anchor: true)
+        app
       end
 
       # Defines a GET-based route.


### PR DESCRIPTION
This builds off of @kainosnoema's work in #49 and allows routing to Rack
applications using HTTP verbs:

``` ruby
class HelloWorld
  def call(env)
    [200, { 'Content-Type' => 'text/plain'}, ['Hello, world!']]
  end
end

class API < Crepe::API
  scope :hello
    get HelloWorld.new
  end

  # Or...
  get :hello, to: HelloWorld.new
end
```

As long as it responds to `call`, it's fair game. However, a few notes:
- One potential syntax could be `get hello: HelloWorld.new`. The current
  implementation of `Crepe::API.route` will end up tossing
  `{:hello=>#<HelloWorld:0x007ff226e7b060}` into the `**options` hash.
  Because that path can be totally aribtrary, parsing that out would get
  quite tricky. Because of this, I haven't supported that syntax.
- This is really the same as `mount HelloWorld.new, at: :hello, method: :get`.
  Do we care about supporting/documenting both?

Signed-off-by: David Celis me@davidcel.is
