### PR TITLE
Rename a couple endpoint config and class method names

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -102,7 +102,7 @@ module Crepe
       def route method, path = '/', **options, &block
         app, path = path, '/' if path.respond_to? :call
         app ||= options.delete :to do
-          Class.new(config[:endpoint]) { handle block || ->{ head } }
+          Class.new(config[:endpoint]) { respond block || ->{ head } }
         end
 
         mount app, options.merge(at: path, method: method, anchor: true)

--- a/lib/crepe/endpoint.rb
+++ b/lib/crepe/endpoint.rb
@@ -33,7 +33,7 @@ module Crepe
       # @return [[Numeric, Hash, #each]]
       delegate :call, to: :new
 
-      def handle handler = nil, &block
+      def respond handler = nil, &block
         @handler = handler || block
         define_method :_run_handler, &@handler
       end

--- a/spec/lib/crepe/endpoint_spec.rb
+++ b/spec/lib/crepe/endpoint_spec.rb
@@ -7,7 +7,7 @@ describe Crepe::Endpoint do
   let(:endpoint) do
     Class.new(described_class).tap do |endpoint|
       endpoint.config.update config
-      endpoint.handle(&handler)
+      endpoint.respond(&handler)
     end
   end
   let(:config) { {} }


### PR DESCRIPTION
Two straightforward renames, neither break documented behavior:
- `API.config[:handler]` to `API.config[:endpoint]`
- `Endpoint.handle` to `Endpoint.respond`

This should reduce confusion and make things a bit friendlier.
