### PR TITLE
Add more flexible parsing

### DIFF
--- a/lib/crepe/endpoint.rb
+++ b/lib/crepe/endpoint.rb
@@ -12,8 +12,9 @@ module Crepe
     @config = {
       callbacks: { before: [], after: [] },
       formats: [:json],
-      parsers: Hash.new(Parser::Simple),
       renderers: Hash.new(Renderer::Simple),
+      parses: [:json],
+      parsers: Hash.new(Parser::Simple),
       rescuers: {
         Params::Missing => -> e { error! :bad_request, e.message, e.data },
         Params::Invalid => -> e { error! :bad_request, e.message, e.data }
@@ -38,15 +39,15 @@ module Crepe
         define_method :_run_handler, &@handler
       end
 
-      # Defines supported formats (mime types) for a scope.
+      # Defines supported response formats (mime types) for a scope.
       #
       #   respond_to :json, :xml
       #
       # These formats will override any that are defined in parent scopes.
       #
-      # Renderers can be defined at the same time:
+      # Renderers can be defined at the same time.
       #
-      #   respond_to csv: CSVRenderer.new
+      #   respond_to csv: CSVRenderer
       #   # class CSVRenderer < Crepe::Renderer::Base
       #   #   def render resource, options = {}
       #   #     super.to_csv
@@ -73,20 +74,38 @@ module Crepe
         formats.each { |f| config[:renderers][f] = renderer }
       end
 
+      # Defines supported request formats (mime types) for a scope.
+      #
+      # E.g., to parse form data instead of the default, JSON:
+      #
+      #   parses(*Rack::Request::FORM_DATA_MEDIA_TYPES)
+      #
+      # These formats will override any that are defined in parent scopes.
+      #
+      # Parsers can be defined at the same time.
+      #
+      #   parses csv: CSVParser
+      #   # class CSVParser < Struct.new :endpoint
+      #   #   def parse body
+      #   #     CSV.table body
+      #   #   end
+      #   # end
+      def parses *media_types, **parsers
+        config[:parses] = media_types | parsers.keys
+        parsers.each { |media_type, parser| parse media_type, with: parser }
+      end
+
       # Defines a custom request body parser for the specified content types.
       #
       #   parse :csv, with: CSVParser.new
-      #   # class CSVParser < Struct.new :endpoint
-      #   #   def parse body
-      #   #     CSV.parse body
-      #   #   end
-      #   # end
+      #
+      # An endpoint must support the media type for it to be parsed.
       #
       # @return [void]
+      # @see .parses
       def parse *media_types, **options
         parser = options.fetch :with
-        media_types = Util.media_types media_types
-        media_types.each { |t| config[:parsers][t] = parser }
+        Util.media_types(media_types).each { |t| config[:parsers][t] = parser }
       end
 
       # Rescues exceptions raised in endpoints.
@@ -341,6 +360,10 @@ module Crepe
     # @return [void]
     # @see API.parse
     def parse body, options = {}
+      unless Util.media_types(config[:parses]).include? request.media_type
+        error! :unsupported_media_type,
+          %(Content-Type "#{request.media_type}" not supported)
+      end
       request.body = parser.parse body
       @params = params.merge request.body if request.body.is_a? Hash
     end

--- a/lib/crepe/parser/simple.rb
+++ b/lib/crepe/parser/simple.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'rack/request'
 
 module Crepe
   module Parser
@@ -15,17 +16,16 @@ module Crepe
 
       def parse body
         case request.media_type
-        when %r{application/x-www-form-urlencoded}, %r{multipart/form-data}
+        when *Rack::Request::FORM_DATA_MEDIA_TYPES
           request.POST
-        when %r{application/json}
+        when 'application/json'
           begin
             JSON.parse body
           rescue JSON::ParserError
             error! :bad_request, "Invalid JSON"
           end
         else
-          error! :unsupported_media_type,
-            %(Content-Type "#{request.media_type}" not supported)
+          body
         end
       end
 

--- a/spec/crepe/parsing_spec.rb
+++ b/spec/crepe/parsing_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Crepe::Parser, 'parsing' do
+  app do
+    post do
+      status :ok
+      params[:ok]
+    end
+  end
+
+  context 'an unsupported media type' do
+    it 'renders Unsupported Media Type' do
+      response = post '/', { ok: 'computer' }, {
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+      }
+      expect(response.status).to eq 415
+    end
+  end
+
+  context 'a registered, parseable media type' do
+    app do
+      parses(*Rack::Request::FORM_DATA_MEDIA_TYPES)
+      post do
+        status :ok
+        request.body['ok']
+      end
+    end
+
+    it 'parses properly' do
+      response = post '/', { ok: 'computer' }, {
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+      }
+      expect(response).to be_ok
+      expect(response.body).to eq '"computer"'
+    end
+  end
+
+  context 'invalid JSON' do
+    it 'renders Bad Request' do
+      response = post '/', '{', 'CONTENT_TYPE' => 'application/json'
+      expect(response.status).to eq 400
+    end
+  end
+
+  context 'valid JSON' do
+    it 'parses properly' do
+      response = post '/', '{"ok":"computer"}', {
+        'CONTENT_TYPE' => 'application/json; charset=utf-8'
+      }
+      expect(response).to be_ok
+      expect(response.body).to eq '"computer"'
+    end
+  end
+
+  context 'a registered, unparseable media type' do
+    app do
+      parses :xml
+      post do
+        head :ok
+        params[:ok]
+      end
+    end
+
+    it 'passes the body through' do
+      response = post '/', '<ok>computer</ok>', {
+        'CONTENT_TYPE' => 'application/xml'
+      }
+      expect(response).to be_ok
+      expect(response.body).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
As it stands, Parser::Simple is, on its own, too simple.

While Endpoint splits responsibility between acceptance and rendering, Endpoint does no such thing between supported media types and parsing.

Why do we need granularity here? Well, the parser supports `application/x-www-form-urlencoded` and `multipart/form-data` by default. This seemed like a good idea at a time, but it actually makes Crepe a bit more difficult to step into because the first time you `curl`-debug, the params you expect to be parsed in from JSON will be `nil` unless you explicitly add `-H "Content-Type: application/json"`. If it returned early with `415 Unsupported Media Type`, it would be a lot easier to debug.

Renderer::Simple supports `to_#{format}` for any format by default, so we shouldn't need to get rid of form data support, but Renderer::Simple won't get hit at all if the format hasn't been whitelisted. We need the same ability to whitelist supported media types.

This commit adds and configures a list of media types an endpoint will parse. In order to parse form data, you must be explicit with the media type, _e.g._:

``` rb
parse 'application/x-www-form-urlencoded', 'multipart/form-data'
# or parse(*Rack::Request::FORM_DATA_MEDIA_TYPES)
```
