### PR TITLE
Explicitly use Endpoint in API where needed

### DIFF
--- a/lib/crepe/api.rb
+++ b/lib/crepe/api.rb
@@ -435,22 +435,22 @@ module Crepe
       # @param [Array<Symbol>] formats a list of formats to respond to
       # @see .generate_options_routes!
       def generate_options_route! path, allowed, formats
-        scope do
-          respond_to(*formats)
-          route 'OPTIONS', path do
-            headers['Allow'] = allowed.join ', '
-            { allow: allowed }
-          end
-          route METHODS - allowed, path do
-            headers['Allow'] = allowed.join ', '
-            error! :method_not_allowed, allow: allowed
-          end
+        respond_to(*formats)
+        route 'OPTIONS', path do
+          headers['Allow'] = allowed.join ', '
+          { allow: allowed }
+        end
+        route METHODS - allowed, path do
+          headers['Allow'] = allowed.join ', '
+          error! :method_not_allowed, allow: allowed
         end
       end
 
       def configured_routes(exclude: [])
-        generate_options_routes!
-        @@catch ||= any('*catch') { error! :not_found } # generate root 404
+        config endpoint: Endpoint do
+          generate_options_routes!
+          @@catch ||= any('*catch') { error! :not_found } # generate root 404
+        end
 
         routes.map do |app, conditions, defaults, config|
           if app.is_a?(Class) && app < API


### PR DESCRIPTION
There are a few locations where we are using the API DSL internally but are not being explicit about the Endpoint class, which means that if someone defines a completely custom Endpoint and it doesn't have, e.g., `#error!` defined, the app won't compile.

This commit mounts these endpoints using the Endpoint class.

We still need to come up with a simple, proper protocol for custom Endpoint classes, but in the meantime, let's not be too prescriptive.
