### PR TITLE
Lock Rack back to 1.6.4, fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ rvm:
   - 2.1.2
 before_install:
   - gem install minitest -v '4.7.5' --no-document --quiet
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
 rvm:
   - 2.1.2
-before_install:
-  - gem install minitest -v '4.7.5' --no-document --quiet
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rack', github: 'rack/rack'
   gem 'puma', github: 'puma/puma'
   gem 'pry'
 end

--- a/crepe.gemspec
+++ b/crepe.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'activesupport', '>= 4.0.0'
-  s.add_dependency 'rack',          '~> 2.0.x'
+  s.add_dependency 'rack',          '~> 1.6.x'
   s.add_dependency 'rack-mount',    '~> 0.8.x'
 
   s.add_development_dependency 'cane',      '~> 2.6.x'

--- a/spec/crepe/middleware_spec.rb
+++ b/spec/crepe/middleware_spec.rb
@@ -47,7 +47,7 @@ describe Crepe::API, "middleware" do
       app { scope(:api) { use middleware } }
 
       it "raises an exception" do
-        expect { app }.to raise_error
+        expect { app }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/lib/crepe/params_spec.rb
+++ b/spec/lib/crepe/params_spec.rb
@@ -13,7 +13,9 @@ describe Crepe::Params do
     end
 
     context 'with a missing key' do
-      it { expect { params.require :missing }.to raise_error }
+      subject { params.require :missing }
+
+      it { expect { subject }.to raise_error(Crepe::Params::Missing) }
     end
   end
 
@@ -35,9 +37,10 @@ describe Crepe::Params do
 
     context 'with an insecure key' do
       let(:input) { { permitted: 1 } }
+      subject { params.permit :invalid }
 
       it { expect(params).not_to be_permitted }
-      it { expect { params.permit :invalid }.to raise_error }
+      it { expect { subject }.to raise_error(Crepe::Params::Invalid) }
     end
   end
 


### PR DESCRIPTION
Rack 2.0.0.alpha isn't in RubyGems, which breaks projects that depend on
Crepe such as Creperie. We don't need to be bundling rack from git, so
lock it back to 1.6.x and remove it from the Gemfile.

Signed-off-by: David Celis <me@davidcel.is>